### PR TITLE
Moved messagebox to only appear once, when done.

### DIFF
--- a/src/TranslateAdmin/MainWindow.xaml.cs
+++ b/src/TranslateAdmin/MainWindow.xaml.cs
@@ -201,8 +201,8 @@ namespace TranslateAdmin
                 {
                     tableClient.UpdateEntity(entity, Azure.ETag.All);
                 }
-                MessageBox.Show("Done");
             }
+            MessageBox.Show("Done");
         }
     }
 }


### PR DESCRIPTION
This message-box pops up for every translation stored. Gets annoying if ther're more than a few, so I guess it should be moved outside the foreach-loop :-)